### PR TITLE
Allow overriding the OpenClaw agent used by workflow runs

### DIFF
--- a/system/cli/clawflows
+++ b/system/cli/clawflows
@@ -1634,7 +1634,9 @@ cmd_run() {
   if [ -n "$oc" ]; then
     echo "Running $name — check your chat with your agent for results."
     echo ""
-    "$oc" agent --agent main -m "Run the $name workflow by following $wf_file" | tee "$run_file"
+    local cf_agent
+    cf_agent="${CLAWFLOWS_OPENCLAW_AGENT:-main}"
+    "$oc" agent --agent "$cf_agent" -m "Run the $name workflow by following $wf_file" | tee "$run_file"
   else
     echo ""
     echo "  ✓ Workflow ready: $name"


### PR DESCRIPTION
## Summary
ClawFlows currently hardcodes `--agent main` when invoking `openclaw agent`, which breaks on hosts whose configured OpenClaw agent is not named `main`.

This patch keeps existing behavior for current users while adding a lightweight escape hatch:
- if `CLAWFLOWS_OPENCLAW_AGENT` is set, use that
- otherwise fall back to `main`

## Why this change
We hit this on a real host where:

```bash
openclaw agents list
```

showed only:

- `sales-agent`

and:

```bash
clawflows run telegram-sales-learning
```

failed because ClawFlows invoked:

```bash
openclaw agent --agent main ...
```

which produced:

```text
Error: Unknown agent id "main". Use "openclaw agents list" to see configured agents.
```

## What this PR changes
Before:

```bash
"$oc" agent --agent main -m "Run the $name workflow by following $wf_file"
```

After:

```bash
local cf_agent
cf_agent="${CLAWFLOWS_OPENCLAW_AGENT:-main}"
"$oc" agent --agent "$cf_agent" -m "Run the $name workflow by following $wf_file"
```

## Why this approach
This is intentionally the smallest possible fix:
- preserves current behavior for existing users
- avoids changing install/update flows
- lets non-`main` deployments work immediately
- keeps the PR easy to review and merge

## How it was verified
Tested on a host where the only registered OpenClaw agent was `sales-agent`.

With:

```bash
CLAWFLOWS_OPENCLAW_AGENT=sales-agent clawflows run telegram-sales-learning
```

the workflow got past agent selection and started normally, instead of failing with `Unknown agent id "main"`.

## Future improvements
A follow-up improvement could make this smoother for new installs by detecting the intended/default OpenClaw agent during install/setup and persisting `CLAWFLOWS_OPENCLAW_AGENT` automatically. That would remove the need for manual env var setup on non-`main` hosts while keeping this PR focused and non-breaking.

