### PR TITLE
fix(create): preserve escaped quotes in --from-json description

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,5 +1,9 @@
 # Updates
 
+## Sun, Apr 19
+
+- 🔧 Fixed `--from-json` truncating the description at the first escaped quote. The old parser used `[^"]*` which halted at any `"` character, including an escaped `\"`, so a description like `Log food with "Breakfast" and "Dinner"` got chopped to `Log food with ` and the rest silently vanished. `create --from-json` now hands JSON off to `jq` when it is installed, so escaped quotes, backslashes, and every other JSON escape survive intact. The grep/sed fallback still runs on systems without jq, with the limitation documented inline. Banana pieces reunited 🍌
+
 ## Sat, Mar 28
 
 - 🟢 **Fixed CI tests for `submit`** — The `submit` command was `die`-ing when it couldn't detect a GitHub remote or username, even though the workflow was already copied successfully. Now those PR automation failures are warnings, not fatal errors — because the banana is already in the basket, we just couldn't mail it yet! CI goes green for the first time in 5 commits 🍌

--- a/system/cli/clawflows
+++ b/system/cli/clawflows
@@ -205,17 +205,35 @@ _create_from_json() {
     die "No JSON provided. Usage: clawflows create --from-json '{...}' or pipe JSON to stdin"
   fi
 
-  # Parse JSON fields (|| true for optional fields that may not exist)
+  # Parse JSON fields. Prefer jq when available so escaped quotes inside string
+  # values (e.g. a description that mentions `"Breakfast"`) survive extraction.
+  # Fall back to grep/sed when jq is missing, matching the prior behavior for
+  # simple values and documenting the limitation below.
   local name emoji summary schedule author description
-  name="$(echo "$json" | grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
-  emoji="$(echo "$json" | grep -o '"emoji"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
-  summary="$(echo "$json" | grep -o '"summary"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
-  schedule="$(echo "$json" | grep -o '"schedule"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
-  author="$(echo "$json" | grep -o '"author"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
-  description="$(echo "$json" | grep -o '"description"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
+  if command -v jq >/dev/null 2>&1; then
+    name="$(printf '%s' "$json" | jq -r '.name // empty' 2>/dev/null || true)"
+    emoji="$(printf '%s' "$json" | jq -r '.emoji // empty' 2>/dev/null || true)"
+    summary="$(printf '%s' "$json" | jq -r '.summary // empty' 2>/dev/null || true)"
+    schedule="$(printf '%s' "$json" | jq -r '.schedule // empty' 2>/dev/null || true)"
+    author="$(printf '%s' "$json" | jq -r '.author // empty' 2>/dev/null || true)"
+    description="$(printf '%s' "$json" | jq -r '.description // empty' 2>/dev/null || true)"
+    # jq -r already decoded JSON escapes (\n, \t, \\, \") into their literal
+    # characters, so no further decoding is needed on this path.
+  else
+    name="$(echo "$json" | grep -o '"name"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
+    emoji="$(echo "$json" | grep -o '"emoji"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
+    summary="$(echo "$json" | grep -o '"summary"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
+    schedule="$(echo "$json" | grep -o '"schedule"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
+    author="$(echo "$json" | grep -o '"author"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
+    # Known limitation without jq: the `[^"]*` class stops at the first `"`
+    # character even when escaped as `\"`, so descriptions that quote words
+    # (e.g. `"Breakfast"`) get truncated. Installing jq (standard on macOS via
+    # Homebrew and on most Linux distros) fixes this.
+    description="$(echo "$json" | grep -o '"description"[[:space:]]*:[[:space:]]*"[^"]*"' | sed 's/.*:.*"\([^"]*\)"/\1/' | head -1 || true)"
 
-  # Decode JSON escape sequences (e.g. \n from textarea input)
-  description="$(printf '%s' "$description" | awk '{gsub(/\\n/,"\n")}1')"
+    # Decode JSON escape sequences (e.g. \n from textarea input)
+    description="$(printf '%s' "$description" | awk '{gsub(/\\n/,"\n")}1')"
+  fi
 
   # Validate required fields
   [ -n "$name" ] || die "Missing required field: name"

--- a/tests/core/create.bats
+++ b/tests/core/create.bats
@@ -177,3 +177,40 @@ Do something useful
     # Should have title case heading
     assert_output --partial "# My Cool Workflow"
 }
+
+# Regression for issue #15: descriptions containing escaped quotes used to
+# get truncated at the first `\"` because the JSON regex used `[^"]*`, which
+# stops at any `"` character including an escaped one. With jq installed the
+# full description should survive.
+@test "create --from-json: preserves escaped quotes in description" {
+    if ! command -v jq >/dev/null 2>&1; then
+        skip "jq not installed; the bash regex fallback cannot handle escaped quotes"
+    fi
+
+    local json='{"name":"quoted-desc","summary":"summary","description":"Log food with \"Breakfast\" and \"Dinner\" slots at \"08:30:00\""}'
+
+    run_clawflows create --from-json "$json"
+
+    assert_success
+    run cat "${CUSTOM_DIR}/quoted-desc/WORKFLOW.md"
+    # The full description, with all three quoted fragments, must be present.
+    assert_output --partial 'Log food with "Breakfast" and "Dinner" slots at "08:30:00"'
+    # And the pre-fix truncation marker (description ending at the first `\"`)
+    # must not appear -- if it did, the body would end with "Log food with "
+    # and drop everything after it.
+    refute_output --partial $'Log food with \n'
+}
+
+@test "create --from-json: preserves backslashes inside description" {
+    if ! command -v jq >/dev/null 2>&1; then
+        skip "jq not installed; the bash regex fallback cannot handle escaped characters"
+    fi
+
+    local json='{"name":"backslash-desc","summary":"summary","description":"Path uses \\\\ as separator"}'
+
+    run_clawflows create --from-json "$json"
+
+    assert_success
+    run cat "${CUSTOM_DIR}/backslash-desc/WORKFLOW.md"
+    assert_output --partial 'Path uses \\ as separator'
+}


### PR DESCRIPTION
## Summary

Closes #15.

\`clawflows create --from-json\` used \`grep\` with \`[^"]*\` to extract each JSON string field. That character class stops at the first \`\"\` it sees, including an escaped \`\\\"\`. A description like \`Log food with \\\"Breakfast\\\" and \\\"Dinner\\\" at \\\"08:30:00\\\"\` got cut off at \`Log food with \` and everything after was silently lost. No error was shown. The WORKFLOW.md ended up with a truncated body.

Hand field extraction off to \`jq -r\` when jq is available. jq parses the JSON properly and decodes every escape (\`\\\"\`, \`\\\\\`, \`\\n\`, \`\\t\`), so the description survives intact and no post-processing is needed. When jq is not installed the original grep/sed path still runs, and an inline comment documents the known truncation on that fallback so the limit is discoverable. This matches the issue author's suggested fix.

## Changes

- \`system/cli/clawflows\`: gate the JSON extraction block on \`command -v jq\`. jq path covers all six fields and relies on jq's built-in escape decoding. grep/sed path kept verbatim for systems without jq, with an inline note about the truncation behavior.
- \`tests/core/create.bats\`: two regression tests that skip cleanly on machines without jq.
  - \`preserves escaped quotes in description\` writes a JSON body with three \`\\\"Breakfast\\\"\`-style fragments and asserts the full string lands in WORKFLOW.md, plus a guard that the pre-fix truncation marker is not present.
  - \`preserves backslashes inside description\` writes a \`\\\\\\\\\` literal and asserts it round-trips as \`\\\\\`.
- \`docs/updates.md\`: one banana-flavored entry per the project's convention.

## Verification

\`\`\`console
$ ./tests/bats/bats-core/bin/bats tests/core/create.bats
1..17
ok 1 create --from-json: creates workflow with all required fields
...
ok 16 create --from-json: preserves escaped quotes in description
ok 17 create --from-json: preserves backslashes inside description
\`\`\`

Reproduction from the issue now works end to end when jq is installed:

\`\`\`bash
clawflows create --from-json '{"name":"test-bug","emoji":"🐛","summary":"test","description":"Log food with \"Breakfast\" meal slot"}'
\`\`\`

The generated WORKFLOW.md now contains the full \`Log food with "Breakfast" meal slot\` body instead of the \`Log food with \` stub.